### PR TITLE
Fix sbt URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@
 var path = require('path');
 var BinWrapper = require('bin-wrapper');
 
-var version = '0.13.9';
+var version = '1.9.8';
 
 var bin = new BinWrapper({skipCheck: true});
-bin.src('https://dl.bintray.com/sbt/native-packages/sbt/' + version + '/sbt-' + version+ '.tgz');
+bin.src('https://github.com/sbt/sbt/releases/download/v' + version + '/sbt-' + version+ '.zip');
 bin.dest(path.join(__dirname, 'vendor'));
 bin.use(process.platform === 'win32' ? 'bin/sbt.bat' : 'bin/sbt');
 


### PR DESCRIPTION
`sbt-bin` had been used here: https://github.com/krausest/js-framework-benchmark/blob/master/frameworks/non-keyed/binding.scala/package.json#L14 However, it is currently broken as Bintray has been shut down.

Also, `sbt-bin` may be still useful for submitting new Scala.js frameworks to the aforementioned front-end benchmark.